### PR TITLE
Add `cluster-admin` impersonation for OIDC users

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,3 +2,6 @@ parameters:
   control_api:
     =_metadata: {}
     namespace: appuio-control-api
+
+    cluster_admin_impersonation:
+      oidc_administrator_role: admin

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -1,0 +1,14 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.control_api;
+
+local defaultLabels = {
+  'app.kubernetes.io/name': 'control-api',
+  'app.kubernetes.io/component': 'control-api',
+  'app.kubernetes.io/managed-by': 'commodore',
+};
+
+{
+  DefaultLabels: defaultLabels,
+}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -7,4 +7,5 @@ local params = inv.parameters.control_api;
 
 // Define outputs below
 {
+  '10_rbac_cluster_admin_impersonation': (import 'rbac-cluster-admin-impersonation.libsonnet'),
 }

--- a/component/rbac-cluster-admin-impersonation.libsonnet
+++ b/component/rbac-cluster-admin-impersonation.libsonnet
@@ -1,0 +1,62 @@
+/*
+* Allows impersonation of the `cluster-admin` user bound to the `cluster-admin` role
+* for users in the configured role.
+*/
+local common = import 'common.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.control_api;
+
+local role = kube.ClusterRole('cluster-admin-impersonator') {
+  metadata+: {
+    labels+: common.DefaultLabels,
+  },
+  rules: [
+    {
+      apiGroups: [
+        '',
+      ],
+      resources: [
+        'users',
+      ],
+      verbs: [
+        'impersonate',
+      ],
+      resourceNames: [
+        'cluster-admin',
+      ],
+    },
+  ],
+};
+
+local roleBinding = kube.ClusterRoleBinding('cluster-admin-impersonator') {
+  metadata+: {
+    labels+: common.DefaultLabels,
+  },
+  roleRef_: role,
+  subjects: [
+    {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'Group',
+      name: params.cluster_admin_impersonation.oidc_administrator_role,
+    },
+  ],
+};
+
+local clusterAdminBinding = kube.ClusterRoleBinding('user-cluster-admin') {
+  metadata+: {
+    labels+: common.DefaultLabels,
+  },
+  roleRef_: kube.ClusterRole('cluster-admin'),
+  subjects: [
+    {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'User',
+      name: 'cluster-admin',
+    },
+  ],
+};
+
+
+[ role, roleBinding, clusterAdminBinding ]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -11,6 +11,15 @@ default:: `appuio-control-api`
 The namespace in which to deploy this component.
 
 
+== `cluster_admin_impersonation.oidc_administrator_role`
+
+[horizontal]
+type:: string
+default:: `admin`
+
+The name of the OpenID Connect role to allow administrator impersonation.
+
+
 == Example
 
 [source,yaml]

--- a/tests/golden/defaults/control-api/control-api/10_rbac_cluster_admin_impersonation.yaml
+++ b/tests/golden/defaults/control-api/control-api/10_rbac_cluster_admin_impersonation.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: control-api
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: control-api
+    name: cluster-admin-impersonator
+  name: cluster-admin-impersonator
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cluster-admin
+    resources:
+      - users
+    verbs:
+      - impersonate
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: control-api
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: control-api
+    name: cluster-admin-impersonator
+  name: cluster-admin-impersonator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin-impersonator
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: control-api
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: control-api
+    name: user-cluster-admin
+  name: user-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: cluster-admin


### PR DESCRIPTION
This PR adds `cluster-admin` impersonation for OIDC users.

On a new vcluster setup to authenticate against `https://id.dev.appuio.cloud/` where I don't have role `admin`:

```sh
❯ kubectl auth can-i list pods  
no
❯ kubectl auth can-i impersonate users/cluster-admin
no
❯ kubectl --as=cluster-admin auth can-i list pods
Error from server (Forbidden): users "cluster-admin" is forbidden: User "sebastian.widmer@vshn.net" cannot impersonate resource "users" in API group "" at the cluster scope
```

On a new vcluster setup to authenticate against `https://id.dev.appuio.cloud/` where I have role `admin`:

```sh
❯ kubectl auth can-i list pods  
no
❯ kubectl auth can-i impersonate users/cluster-admin
yes
❯ kubectl --as=cluster-admin auth can-i list pods
yes
```

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
