### PR TITLE
Simplify dependency fetching

### DIFF
--- a/class/control-api.yml
+++ b/class/control-api.yml
@@ -5,40 +5,11 @@ parameters:
         source: https://github.com/appuio/control-api/releases/download/${control_api:images:control-api:tag}/crd.yaml
         output_path: dependencies/control-api/crds/${control_api:images:control-api:tag}/01_crds.yaml
 
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/rbac/role.yaml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/apiserver/role.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/rbac/role_binding.yaml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/apiserver/role_binding.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/rbac/role_binding_auth_delegator.yaml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/apiserver/role_binding_auth_delegator.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/rbac/service_account.yaml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/apiserver/service_account.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/deployment/deployment.yaml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/apiserver/deployment.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/deployment/service.yaml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/apiserver/service.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/deployment/apiservice.yaml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/apiserver/apiservice.yaml
-
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/user-rbac/basic-user-role.yml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/rbac/basic-user-role.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/user-rbac/basic-user-rolebinding.yml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/rbac/basic-user-rolebinding.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/user-rbac/organization-admin-role.yml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/rbac/organization-admin-role.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/control-api/${control_api:images:control-api:tag}/config/user-rbac/organization-viewer-role.yml
-        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/rbac/organization-viewer-role.yaml
+      - type: git
+        output_path: dependencies/control-api/manifests/${control_api:images:control-api:tag}/
+        source: https://github.com/appuio/control-api.git
+        subdir: config
+        ref: ${control_api:images:control-api:tag}
 
       - type: https
         source: https://raw.githubusercontent.com/${control_api:images:idp-adapter:image}/${control_api:images:idp-adapter:tag}/config/rbac/role.yaml

--- a/component/api-server.jsonnet
+++ b/component/api-server.jsonnet
@@ -7,13 +7,13 @@ local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.control_api;
 
-local serviceAccount = common.LoadManifest('apiserver/service_account.yaml') {
+local serviceAccount = common.LoadManifest('rbac/service_account.yaml') {
   metadata+: {
     namespace: params.namespace,
   },
 };
 
-local role = common.LoadManifest('apiserver/role.yaml');
+local role = common.LoadManifest('rbac/role.yaml');
 
 local certSecret =
   if params.apiserver.tls.certSecretName != null then
@@ -46,7 +46,7 @@ local extraDeploymentArgs =
 ;
 
 
-local deployment = common.LoadManifest('apiserver/deployment.yaml') {
+local deployment = common.LoadManifest('deployment/deployment.yaml') {
   metadata+: {
     namespace: params.namespace,
   },
@@ -80,7 +80,7 @@ local deployment = common.LoadManifest('apiserver/deployment.yaml') {
   },
 };
 
-local service = common.LoadManifest('apiserver/service.yaml') {
+local service = common.LoadManifest('deployment/service.yaml') {
   metadata+: {
     namespace: params.namespace,
   },
@@ -106,7 +106,7 @@ local service = common.LoadManifest('apiserver/service.yaml') {
       },
     ],
   },
-  '01_role_binding_auth_delegator': common.LoadManifest('apiserver/role_binding_auth_delegator.yaml') {
+  '01_role_binding_auth_delegator': common.LoadManifest('rbac/role_binding_auth_delegator.yaml') {
     subjects: [
       {
         kind: 'ServiceAccount',
@@ -119,7 +119,7 @@ local service = common.LoadManifest('apiserver/service.yaml') {
   '02_deployment': deployment,
   [if certSecret != null then '02_certs']: certSecret,
   '02_service': service,
-  '02_apiservice': common.LoadManifest('apiserver/apiservice.yaml') {
+  '02_apiservice': common.LoadManifest('deployment/apiservice.yaml') {
     spec+: {
              service: {
                name: service.metadata.name,

--- a/component/rbac-basic-user.libsonnet
+++ b/component/rbac-basic-user.libsonnet
@@ -7,13 +7,13 @@ local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.control_api;
 
-local role = common.LoadManifest('rbac/basic-user-role.yaml') {
+local role = common.LoadManifest('user-rbac/basic-user-role.yml') {
   metadata+: {
     labels+: common.DefaultLabels,
   },
 };
 
-local roleBinding = common.LoadManifest('rbac/basic-user-rolebinding.yaml') {
+local roleBinding = common.LoadManifest('user-rbac/basic-user-rolebinding.yml') {
   metadata+: {
     labels+: common.DefaultLabels,
   },

--- a/component/rbac-organization.libsonnet
+++ b/component/rbac-organization.libsonnet
@@ -8,13 +8,13 @@ local inv = kap.inventory();
 local params = inv.parameters.control_api;
 
 
-local adminrole = common.LoadManifest('rbac/organization-admin-role.yaml') {
+local adminrole = common.LoadManifest('user-rbac/organization-admin-role.yml') {
   metadata+: {
     labels+: common.DefaultLabels,
   },
 };
 
-local viewrole = common.LoadManifest('rbac/organization-viewer-role.yaml') {
+local viewrole = common.LoadManifest('user-rbac/organization-viewer-role.yml') {
   metadata+: {
     labels+: common.DefaultLabels,
   },


### PR DESCRIPTION
Download all manifests at once using the `git` type. Makes it simpler for the next release where every manifest will be moved around.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
