### PR TITLE
Fix tenant name reclass references

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,7 +18,7 @@ parameters:
       tls:
         certSecretName: control-api-tls
         serverCert: ""
-        serverKey: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/apiserver-key}"
+        serverKey: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/apiserver-key}"
 
     controller:
       extraArgs: []
@@ -26,7 +26,7 @@ parameters:
         certSecretName: webhook-service-tls
         caCertificate: ""
         certificate: ""
-        key: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/webhook-key}"
+        key: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/webhook-key}"
 
     idp_adapter:
       enabled: false

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -52,7 +52,7 @@ default:: ""
 
 === `apiserver.tls.serverKey`
 type:: string
-default:: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/apiserver-key}"
+default:: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/apiserver-key}"
 
 == `zones`
 
@@ -155,7 +155,7 @@ Users must provide this parameter, since Kubernetes doesn't support admission we
 
 [horizontal]
 type:: string
-default:: `?{vaultkv:${customer:name}/${cluster:name}/${_instance}/webhook-key}`
+default:: `?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/webhook-key}`
 
 The private key to use for the controller's admission webhook server.
 


### PR DESCRIPTION
We've deprecated `customer.name` a while ago.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
