### PR TITLE
Add runbook for "E-Mail Sending Stuck" alert

### DIFF
--- a/docs/modules/ROOT/pages/runbooks/InvitationEmailStuck.adoc
+++ b/docs/modules/ROOT/pages/runbooks/InvitationEmailStuck.adoc
@@ -1,0 +1,32 @@
+= Alert rule: PatchReconcileErrors
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+This alert fires if any Invitation objects have an EmailSent status of "False".
+This is usually the result of an error during e-mail sending.
+
+== icon:bug[] Steps for debugging
+
+
+=== Check the status of the invitation resources
+
+[source,shell]
+----
+$ kubectl get invitations -o custom-columns='NAME:.metadata.name,EmailSent:{status.conditions[?(@.type=="EmailSent")].status},EmailSentReason:{status.conditions[?(@.type=="EmailSent")].reason},EmailSentMessage:{status.conditions[?(@.type=="EmailSent")].message}'
+----
+
+Check for invitations with `EmailSent = False`.
+They should contain the associated error message.
+
+The error message should hopefully identify the underlying problem, which can then be fixed in the appropriate place.
+This may be in the invitation resource itself, or in the e-mail backend (such as Mailgun).
+
+=== Check the logs of the controller
+
+If the error message is lacking context, the logs of the controller can be checked additionally:
+[source,shell]
+----
+$ kubectl -n control-api logs deploy/control-api-controller -c controller
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -4,3 +4,6 @@
 
 .Technical Reference
 * xref:references/parameters.adoc[Parameters]
+
+.Runbooks
+* xref:runbooks/InvitationEmailStuck.adoc[Invitation E-Mail Stuck]

--- a/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
+++ b/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
@@ -1,0 +1,5 @@
+[NOTE]
+====
+Please consider opening a PR to improve this runbook if you gain new information about causes of the alert, or how to debug or resolve the alert.
+Click "Edit this Page" in the top right corner to create a PR directly on GitHub.
+====


### PR DESCRIPTION
The alert is (for now) defined in the global commodore defaults.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
