### PR TITLE
Always restart apiserver when the country list is updated

### DIFF
--- a/component/api-server.jsonnet
+++ b/component/api-server.jsonnet
@@ -83,6 +83,12 @@ local deployment = common.LoadManifest('deployment/apiserver/deployment.yaml') {
 
   spec+: {
     template+: {
+      [if hasCountriesConfig then 'metadata']+: {
+        annotations+: {
+          'checksum/countries':
+            std.md5(countriesConfigMap.data['billing_entity_odoo8_country_list.yaml']),
+        },
+      },
       spec+:
         {
           containers: [

--- a/tests/golden/defaults/control-api/control-api/01_api_server/02_deployment.yaml
+++ b/tests/golden/defaults/control-api/control-api/01_api_server/02_deployment.yaml
@@ -12,6 +12,8 @@ spec:
       app: control-api-apiserver
   template:
     metadata:
+      annotations:
+        checksum/countries: a625c0049a00749c1685fc458f98b3f1
       labels:
         app: control-api-apiserver
     spec:


### PR DESCRIPTION
Add an annotation containing the md5 hash of the country list in the apiserver template metadata to force a new replicaset when the country list changes.

Discovered during rollout of #81 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
