### PR TITLE
Add ServiceAccount which can access Control API apiserver metrics

### DIFF
--- a/tests/golden/defaults/control-api/control-api/01_api_server/03_api_metrics_rbac.yaml
+++ b/tests/golden/defaults/control-api/control-api/01_api_server/03_api_metrics_rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: metrics
+  name: metrics
+  namespace: appuio-control-api
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics
+    vcluster.loft.sh/force-sync: 'true'
+  labels:
+    name: metrics
+  name: metrics
+  namespace: appuio-control-api
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: metrics
+  name: metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:monitoring
+subjects:
+  - kind: ServiceAccount
+    name: metrics
+    namespace: appuio-control-api

--- a/tests/golden/insecure/control-api/control-api/01_api_server/03_api_metrics_rbac.yaml
+++ b/tests/golden/insecure/control-api/control-api/01_api_server/03_api_metrics_rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: metrics
+  name: metrics
+  namespace: appuio-control-api
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics
+    vcluster.loft.sh/force-sync: 'true'
+  labels:
+    name: metrics
+  name: metrics
+  namespace: appuio-control-api
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: metrics
+  name: metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:monitoring
+subjects:
+  - kind: ServiceAccount
+    name: metrics
+    namespace: appuio-control-api

--- a/tests/golden/withcronjob/control-api/control-api/01_api_server/03_api_metrics_rbac.yaml
+++ b/tests/golden/withcronjob/control-api/control-api/01_api_server/03_api_metrics_rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: metrics
+  name: metrics
+  namespace: appuio-control-api
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics
+    vcluster.loft.sh/force-sync: 'true'
+  labels:
+    name: metrics
+  name: metrics
+  namespace: appuio-control-api
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: metrics
+  name: metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:monitoring
+subjects:
+  - kind: ServiceAccount
+    name: metrics
+    namespace: appuio-control-api


### PR DESCRIPTION
Configure ServiceAccount, long-lived token, and ClusterRoleBinding to `system:monitoring` to allow the service account access to the apiserver `/metrics` API endpoint.

We pick a very short name for the service account and secret, so that there's a reasonable chance that the name won't get mangled when the secret is synced from a vcluster instance into the host cluster, if the control-api is deployed in a vcluster.

Additionally, we add annotation `vcluster.loft.sh/force-sync=true` to the token secret to ensure that this secret is available in the host cluster to allow us to scrape metrics.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
