### PR TITLE
Inject `name` label for apiserver and controller-metrics services

### DIFF
--- a/component/api-controller.jsonnet
+++ b/component/api-controller.jsonnet
@@ -106,6 +106,9 @@ local admissionWebhookService = common.LoadManifest('webhook/service.yaml') {
 local metricsService = common.LoadManifest('deployment/controller/metrics-service.yaml') {
   metadata+: {
     namespace: params.namespace,
+    labels+: {
+      name: $.metadata.name,
+    },
   },
   spec+: {
     ports: [

--- a/component/api-server.jsonnet
+++ b/component/api-server.jsonnet
@@ -145,6 +145,9 @@ local deployment = common.LoadManifest('deployment/apiserver/deployment.yaml') {
 local service = common.LoadManifest('deployment/apiserver/service.yaml') {
   metadata+: {
     namespace: params.namespace,
+    labels+: {
+      name: $.metadata.name,
+    },
   },
   spec+: {
     selector: deployment.spec.selector.matchLabels,

--- a/tests/golden/defaults/control-api/control-api/01_api_server/02_service.yaml
+++ b/tests/golden/defaults/control-api/control-api/01_api_server/02_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    name: control-api-apiserver
   name: control-api-apiserver
   namespace: appuio-control-api
 spec:

--- a/tests/golden/defaults/control-api/control-api/02_api_controller/12_metrics_service.yaml
+++ b/tests/golden/defaults/control-api/control-api/02_api_controller/12_metrics_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app: control-api-controller
+    name: control-api-controller-metrics
   name: control-api-controller-metrics
   namespace: appuio-control-api
 spec:

--- a/tests/golden/insecure/control-api/control-api/01_api_server/02_service.yaml
+++ b/tests/golden/insecure/control-api/control-api/01_api_server/02_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    name: control-api-apiserver
   name: control-api-apiserver
   namespace: appuio-control-api
 spec:

--- a/tests/golden/insecure/control-api/control-api/02_api_controller/12_metrics_service.yaml
+++ b/tests/golden/insecure/control-api/control-api/02_api_controller/12_metrics_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app: control-api-controller
+    name: control-api-controller-metrics
   name: control-api-controller-metrics
   namespace: appuio-control-api
 spec:

--- a/tests/golden/withcronjob/control-api/control-api/01_api_server/02_service.yaml
+++ b/tests/golden/withcronjob/control-api/control-api/01_api_server/02_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    name: control-api-apiserver
   name: control-api-apiserver
   namespace: appuio-control-api
 spec:

--- a/tests/golden/withcronjob/control-api/control-api/02_api_controller/12_metrics_service.yaml
+++ b/tests/golden/withcronjob/control-api/control-api/02_api_controller/12_metrics_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app: control-api-controller
+    name: control-api-controller-metrics
   name: control-api-controller-metrics
   namespace: appuio-control-api
 spec:


### PR DESCRIPTION
This will allow us to select these services through label `vcluster.loft.sh/label-<vcluster-name>-x-$(echo -n 'name' | sha256sum | head -c 10)` on the host cluster, if the component is installed in a vcluster.

See https://github.com/loft-sh/vcluster/blob/cf91a6705d9192578f020ca6ad73327e0708014c/pkg/util/translate/single_namespace.go#L292-L295 for the label key transformer in the vcluster implementation.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
