### PR TITLE
Remove workaround to simulate empty key in config

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -104,8 +104,7 @@ parameters:
           code: CH
           id: 44
         # Maps BEs with empty countries to Switzerland automatically.
-        # We can't use "" as key because Reclass doesn't like empty dict keys.
-        __empty__:
+        "":
           code: CH
           id: 44
         United Kingdom:

--- a/component/api-server.jsonnet
+++ b/component/api-server.jsonnet
@@ -59,7 +59,7 @@ local extraDeploymentArgs =
 local countryList = std.filterMap(
   function(name) params.odoo8.countries[name] != null,
   function(name) {
-    name: if name == '__empty__' then '' else name,
+    name: name,
     code: params.odoo8.countries[name].code,
     id: params.odoo8.countries[name].id,
   },

--- a/tests/golden/defaults/control-api/control-api/01_api_server/01_countries_configmap.yaml
+++ b/tests/golden/defaults/control-api/control-api/01_api_server/01_countries_configmap.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 data:
   billing_entity_odoo8_country_list.yaml: |-
+    - "code": "CH"
+      "id": 44
+      "name": ""
     - "code": "AT"
       "id": 13
       "name": "Austria"
@@ -97,9 +100,6 @@ data:
     - "code": "US"
       "id": 235
       "name": "United States"
-    - "code": "CH"
-      "id": 44
-      "name": ""
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/defaults/control-api/control-api/01_api_server/02_deployment.yaml
+++ b/tests/golden/defaults/control-api/control-api/01_api_server/02_deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/countries: 3d77fba4c0d674be0911de6ec943c0f6
+        checksum/countries: 49d20409af18c4c3dd43af7ee501778a
       labels:
         app: control-api-apiserver
     spec:

--- a/tests/golden/withcronjob/control-api/control-api/01_api_server/01_countries_configmap.yaml
+++ b/tests/golden/withcronjob/control-api/control-api/01_api_server/01_countries_configmap.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 data:
   billing_entity_odoo8_country_list.yaml: |-
+    - "code": "CH"
+      "id": 44
+      "name": ""
     - "code": "AT"
       "id": 13
       "name": "Austria"
@@ -97,9 +100,6 @@ data:
     - "code": "US"
       "id": 235
       "name": "United States"
-    - "code": "CH"
-      "id": 44
-      "name": ""
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/withcronjob/control-api/control-api/01_api_server/02_deployment.yaml
+++ b/tests/golden/withcronjob/control-api/control-api/01_api_server/02_deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/countries: 3d77fba4c0d674be0911de6ec943c0f6
+        checksum/countries: 49d20409af18c4c3dd43af7ee501778a
       labels:
         app: control-api-apiserver
     spec:


### PR DESCRIPTION
Our reclass in Rust implementation handles empty keys fine (as long as you don't try to use them in parameter references), so we can remove the workaround in the component.

Follow-up for #85 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
