### PR TITLE
Fix merging for zone definitions

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -10,7 +10,8 @@ local params = inv.parameters.control_api;
 
 
 local zones = [
-  controlApi.Zone(name) + params.zones[name] {
+  controlApi.Zone(name) +
+  com.makeMergeable(params.zones[name]) {
     metadata+: {
       labels+: common.DefaultLabels,
     },

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -93,6 +93,9 @@ parameters:
 
     zones:
       example-zone-1:
+        metadata:
+          labels:
+            control.appuio.io/zone-cluster-id: c-appuio-example1
         data:
           displayName: Example Zone 1
           features:

--- a/tests/golden/defaults/control-api/control-api/20_zones.yaml
+++ b/tests/golden/defaults/control-api/control-api/20_zones.yaml
@@ -23,6 +23,7 @@ metadata:
     app.kubernetes.io/component: control-api
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: control-api
+    control.appuio.io/zone-cluster-id: c-appuio-example1
     name: example-zone-1
   name: example-zone-1
 ---


### PR DESCRIPTION
Without this commit, setting `metadata.labels` on a zone would delete some important metadata such as `metadata.name`. To avoid this, we call `com.makeMergeable()` on the user-provided partial zone object.

Required to set label for zone mapping for https://github.com/appuio/appuio-cloud-agent/pull/133 since we currently don't require that the zones are named identically to the Project Syn cluster ID of the zone.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
